### PR TITLE
Fixing balance helper function

### DIFF
--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -29,7 +29,7 @@ function format_number(float $number)
  * @param  string|null  $startDate
  * @return float
  */
-function balance($perDate = null, $startDate = null)
+function balance($perDate = null, $startDate = null, $categoryId = null)
 {
     $transactionQuery = DB::table('transactions');
     if ($perDate) {
@@ -37,6 +37,9 @@ function balance($perDate = null, $startDate = null)
     }
     if ($startDate) {
         $transactionQuery->where('date', '>=', $startDate);
+    }
+    if ($categoryId) {
+        $transactionQuery->where('category_id', $categoryId);
     }
     $transactions = $transactionQuery->where('creator_id', auth()->id())->get();
 

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -29,7 +29,7 @@ function format_number(float $number)
  * @param  string|null  $startDate
  * @return float
  */
-function balance($perDate = null, $startDate = null, $categoryId = null)
+function balance($perDate = null, $startDate = null, $categoryId = null, $partnerId = null)
 {
     $transactionQuery = DB::table('transactions');
     if ($perDate) {
@@ -40,6 +40,9 @@ function balance($perDate = null, $startDate = null, $categoryId = null)
     }
     if ($categoryId) {
         $transactionQuery->where('category_id', $categoryId);
+    }
+    if ($partnerId) {
+        $transactionQuery->where('partner_id', $partnerId);
     }
     $transactions = $transactionQuery->where('creator_id', auth()->id())->get();
 

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -91,7 +91,7 @@
                                 $balance = 0;
                             @endphp
                             @if ($transactions->last())
-                                {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
+                                {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d')), null, request('category_id'), request('partner_id')) }}
                             @else
                                 0
                             @endif

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -82,6 +82,26 @@
                     <tr><td colspan="5">{{ __('transaction.not_found') }}</td></tr>
                     @endforelse
                 </tbody>
+                @if (request('category_id') || request('partner_id'))
+                <tfoot>
+                    <tr><th colspan="5" class="text-right">&nbsp;</th></tr>
+                    <tr>
+                        <th colspan="3" class="text-right">{{ __('transaction.income_total') }}</th>
+                        <th class="text-right">{{ format_number($incomeTotal) }}</th>
+                        <th>&nbsp;</th>
+                    </tr>
+                    <tr>
+                        <th colspan="3" class="text-right">{{ __('transaction.spending_total') }}</th>
+                        <th class="text-right">{{ format_number($spendingTotal) }}</th>
+                        <th>&nbsp;</th>
+                    </tr>
+                    <tr>
+                        <th colspan="3" class="text-right">{{ __('transaction.difference') }}</th>
+                        <th class="text-right">{{ number_format($incomeTotal - $spendingTotal, 2) }}</th>
+                        <th>&nbsp;</th>
+                    </tr>
+                </tfoot>
+                @else
                 <tfoot>
                     <tr><th colspan="5" class="text-right">&nbsp;</th></tr>
                     <tr>
@@ -91,7 +111,7 @@
                                 $balance = 0;
                             @endphp
                             @if ($transactions->last())
-                                {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d')), null, request('category_id'), request('partner_id')) }}
+                                {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
                             @else
                                 0
                             @endif
@@ -120,6 +140,7 @@
                         <th>&nbsp;</th>
                     </tr>
                 </tfoot>
+                @endif
             </table>
             @elsedesktop
             <div class="panel-body">

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -87,8 +87,11 @@
                     <tr>
                         <th colspan="3" class="text-right">{{ __('transaction.start_balance') }}</th>
                         <th class="text-right">
+                            @php
+                                $balance = 0;
+                            @endphp
                             @if ($transactions->last())
-                                {{ format_number(balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
+                                {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
                             @else
                                 0
                             @endif
@@ -109,7 +112,7 @@
                         <th colspan="3" class="text-right">{{ __('transaction.end_balance') }}</th>
                         <th class="text-right">
                             @if ($transactions->first())
-                                {{ format_number(balance($transactions->first()->date)) }}
+                                {{ format_number($balance + $incomeTotal - $spendingTotal) }}
                             @else
                                 0
                             @endif

--- a/resources/views/transactions/partials/stats.blade.php
+++ b/resources/views/transactions/partials/stats.blade.php
@@ -1,8 +1,8 @@
 <div class="panel panel-default table-responsive">
     <table class="table table-condensed table-bordered">
         <tr>
-            <td class="col-xs-2 text-center">{{ trans('transaction.income_total') }}</td>
-            <td class="col-xs-2 text-center">{{ trans('transaction.spending_total') }}</td>
+            <td class="col-xs-2 text-center">{{ trans('transaction.income') }}</td>
+            <td class="col-xs-2 text-center">{{ trans('transaction.spending') }}</td>
             <td class="col-xs-2 text-center">{{ trans('transaction.difference') }}</td>
         </tr>
         <tr>

--- a/resources/views/transactions/partials/transaction_summary_mobile.blade.php
+++ b/resources/views/transactions/partials/transaction_summary_mobile.blade.php
@@ -5,7 +5,7 @@
             $balance = 0;
         @endphp
         @if ($transactions->last())
-            {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
+            {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d')), null, request('category_id'), request('partner_id')) }}
         @else
             0
         @endif

--- a/resources/views/transactions/partials/transaction_summary_mobile.blade.php
+++ b/resources/views/transactions/partials/transaction_summary_mobile.blade.php
@@ -1,32 +1,46 @@
-<div class="row">
-    <div class="col-xs-6 text-right strong">{{ __('transaction.start_balance') }}</div>
-    <div class="col-xs-6 text-right strong">
-        @php
-            $balance = 0;
-        @endphp
-        @if ($transactions->last())
-            {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d')), null, request('category_id'), request('partner_id')) }}
-        @else
-            0
-        @endif
+@if (request('category_id') || request('partner_id'))
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.income_total') }}</div>
+        <div class="col-xs-6 text-right strong">{{ format_number($incomeTotal) }}</div>
     </div>
-</div>
-<div class="row">
-    <div class="col-xs-6 text-right strong">{{ __('transaction.income_total') }}</div>
-    <div class="col-xs-6 text-right strong">{{ format_number($incomeTotal) }}</div>
-</div>
-<div class="row">
-    <div class="col-xs-6 text-right strong">{{ __('transaction.spending_total') }}</div>
-    <div class="col-xs-6 text-right strong">{{ format_number($spendingTotal) }}</div>
-</div>
-<div class="row">
-    <div class="col-xs-6 text-right strong">{{ __('transaction.end_balance') }}</div>
-    <div class="col-xs-6 text-right strong">
-        @if ($transactions->first())
-            {{ format_number($balance + $incomeTotal - $spendingTotal) }}
-        @else
-            0
-        @endif
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.spending_total') }}</div>
+        <div class="col-xs-6 text-right strong">{{ format_number($spendingTotal) }}</div>
     </div>
-</div>
-</div>
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.end_balance') }}</div>
+        <div class="col-xs-6 text-right strong">{{ number_format($incomeTotal - $spendingTotal, 2) }}</div>
+    </div>
+@else
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.start_balance') }}</div>
+        <div class="col-xs-6 text-right strong">
+            @php
+                $balance = 0;
+            @endphp
+            @if ($transactions->last())
+                {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
+            @else
+                0
+            @endif
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.income_total') }}</div>
+        <div class="col-xs-6 text-right strong">{{ format_number($incomeTotal) }}</div>
+    </div>
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.spending_total') }}</div>
+        <div class="col-xs-6 text-right strong">{{ format_number($spendingTotal) }}</div>
+    </div>
+    <div class="row">
+        <div class="col-xs-6 text-right strong">{{ __('transaction.end_balance') }}</div>
+        <div class="col-xs-6 text-right strong">
+            @if ($transactions->first())
+                {{ format_number($balance + $incomeTotal - $spendingTotal) }}
+            @else
+                0
+            @endif
+        </div>
+    </div>
+@endif

--- a/resources/views/transactions/partials/transaction_summary_mobile.blade.php
+++ b/resources/views/transactions/partials/transaction_summary_mobile.blade.php
@@ -1,8 +1,11 @@
 <div class="row">
     <div class="col-xs-6 text-right strong">{{ __('transaction.start_balance') }}</div>
     <div class="col-xs-6 text-right strong">
+        @php
+            $balance = 0;
+        @endphp
         @if ($transactions->last())
-            {{ format_number(balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
+            {{ format_number($balance = balance(Carbon\Carbon::parse($transactions->last()->date)->subDay()->format('Y-m-d'))) }}
         @else
             0
         @endif
@@ -20,7 +23,7 @@
     <div class="col-xs-6 text-right strong">{{ __('transaction.end_balance') }}</div>
     <div class="col-xs-6 text-right strong">
         @if ($transactions->first())
-            {{ format_number(balance($transactions->first()->date)) }}
+            {{ format_number($balance + $incomeTotal - $spendingTotal) }}
         @else
             0
         @endif

--- a/tests/Unit/Helpers/BalanceFunctionTest.php
+++ b/tests/Unit/Helpers/BalanceFunctionTest.php
@@ -112,6 +112,19 @@ class BalanceFunctionTest extends TestCase
     }
 
     /** @test */
+    public function balance_function_accepts_category_id_and_partner_id_parameter()
+    {
+        $user = $this->loginAsUser();
+
+        factory(Transaction::class)->create(['date' => '2015-01-03', 'amount' => 10000, 'in_out' => 1, 'creator_id' => $user->id, 'category_id' => 1, 'partner_id' => 1]);
+        factory(Transaction::class)->create(['date' => '2015-01-05', 'amount' => 900, 'in_out' => 0, 'creator_id' => $user->id, 'category_id' => 1, 'partner_id' => 2]);
+        factory(Transaction::class)->create(['date' => '2015-01-20', 'amount' => 4000, 'in_out' => 1, 'creator_id' => $user->id, 'category_id' => 2, 'partner_id' => 2]);
+
+        // Assert balance from '2015-01-03' until '2015-01-30' with category_id 1 and partner_id 2
+        $this->assertEquals(-900, balance('2015-01-31', '2015-01-03', 1, 2));
+    }
+
+    /** @test */
     public function unauthenticated_user_has_0_balance()
     {
         factory(Transaction::class)->create();

--- a/tests/Unit/Helpers/BalanceFunctionTest.php
+++ b/tests/Unit/Helpers/BalanceFunctionTest.php
@@ -97,6 +97,21 @@ class BalanceFunctionTest extends TestCase
     }
 
     /** @test */
+    public function balance_function_accepts_partner_id_parameter()
+    {
+        $user = $this->loginAsUser();
+
+        // Other transaction with different partner_id
+        factory(Transaction::class)->create(['date' => '2015-01-03', 'amount' => 10000, 'in_out' => 1, 'creator_id' => $user->id, 'partner_id' => 1]);
+
+        factory(Transaction::class)->create(['date' => '2015-01-05', 'amount' => 900, 'in_out' => 0, 'creator_id' => $user->id, 'partner_id' => 2]);
+        factory(Transaction::class)->create(['date' => '2015-01-20', 'amount' => 4000, 'in_out' => 1, 'creator_id' => $user->id, 'partner_id' => 2]);
+
+        // Assert balance from '2015-01-03' until '2015-01-30' with no category and partner_id 2
+        $this->assertEquals(3100, balance('2015-01-31', '2015-01-03', null, 2));
+    }
+
+    /** @test */
     public function unauthenticated_user_has_0_balance()
     {
         factory(Transaction::class)->create();

--- a/tests/Unit/Helpers/BalanceFunctionTest.php
+++ b/tests/Unit/Helpers/BalanceFunctionTest.php
@@ -82,6 +82,21 @@ class BalanceFunctionTest extends TestCase
     }
 
     /** @test */
+    public function balance_function_accepts_category_id_parameter()
+    {
+        $user = $this->loginAsUser();
+
+        // Other transaction with different category_id
+        factory(Transaction::class)->create(['date' => '2015-01-03', 'amount' => 10000, 'in_out' => 1, 'creator_id' => $user->id, 'category_id' => 1]);
+
+        factory(Transaction::class)->create(['date' => '2015-01-05', 'amount' => 900, 'in_out' => 0, 'creator_id' => $user->id, 'category_id' => 2]);
+        factory(Transaction::class)->create(['date' => '2015-01-20', 'amount' => 4000, 'in_out' => 1, 'creator_id' => $user->id, 'category_id' => 2]);
+
+        // Assert balance from '2015-01-03' until '2015-01-30' with category_id 2
+        $this->assertEquals(3100, balance('2015-01-31', '2015-01-03', 2));
+    }
+
+    /** @test */
     public function unauthenticated_user_has_0_balance()
     {
         factory(Transaction::class)->create();


### PR DESCRIPTION
Berdasarkan informasi mas @satyakresna pada issue #12 ditemukan bahwa saldo akhir keliru jika list transaksi difilter berdasarkan kategori.

Pada PR ini, kita menabahkankan parameter $categoryId (default null) pada function `balance` https://github.com/nafiesl/dompet/blob/e0dba2ec84f4819fe8a11caf0787f09e8962ce0a/app/Helpers/functions.php#L32 agar saldo juga dihitung sesuai dengan kategori yang dipilih user.