### PR TITLE
Redirect authenticated users to home page instead of welcome page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@
 |
 */
 
-Route::view('/', 'welcome')->name('welcome');
+Route::view('/', 'welcome')->name('welcome')->middleware('guest');
 
 Auth::routes();
 

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -78,7 +78,7 @@ class LoginTest extends TestCase
         $user = $this->loginAsUser();
 
         $this->seeIsAuthenticated();
-        $this->visit(route('home'));
+        $this->visit(route('welcome'));
         $this->seePageIs(route('home'));
     }
 }

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -71,4 +71,14 @@ class LoginTest extends TestCase
         $this->visit(route('home'));
         $this->seePageIs(route('login'));
     }
+
+    /** @test */
+    public function authenticated_users_are_redirects_to_home_page()
+    {
+        $user = $this->loginAsUser();
+
+        $this->seeIsAuthenticated();
+        $this->visit(route('home'));
+        $this->seePageIs(route('home'));
+    }
 }


### PR DESCRIPTION
Ketika user sudah login sebelumnya dan membuka browser kembali maka semestinya user diarahkan ke route **home** bukan route **welcome**. Saya sedang mencoba membuat feature testnya tetapi sepertinya saya ragu apakah benar feature testnya atau tidak? Karena ketika saya hapus `middleware('guest')` dari web dan saya test kembali malah berjalan lancar. Mohon bantuannya utk dikoreksi mas. 🏳