### PR TITLE
Add Category and Partner Transaction Listing Default Start Date

### DIFF
--- a/app/Http/Controllers/Auth/ProfileController.php
+++ b/app/Http/Controllers/Auth/ProfileController.php
@@ -40,8 +40,9 @@ class ProfileController extends Controller
     public function update(Request $request)
     {
         $userData = $request->validate([
-            'name'  => 'required|max:60',
-            'email' => 'required|max:255|unique:users,email,'.auth()->id(),
+            'name'               => 'required|max:60',
+            'email'              => 'required|max:255|unique:users,email,'.auth()->id(),
+            'account_start_date' => 'nullable|date',
         ]);
 
         auth()->user()->update($userData);

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -55,8 +55,11 @@ class CategoriesController extends Controller
         $editableTransaction = null;
         $year = request('year', date('Y'));
         $partners = $this->getPartnerList();
-        $startDate = request('start_date', date('Y-m').'-01');
+
+        $defaultStartDate = auth()->user()->account_start_date ?: date('Y-m').'-01';
+        $startDate = request('start_date', $defaultStartDate);
         $endDate = request('end_date', date('Y-m-d'));
+
         $transactions = $this->getCategoryTransactions($category, [
             'partner_id' => request('partner_id'),
             'start_date' => $startDate,

--- a/app/Http/Controllers/PartnerController.php
+++ b/app/Http/Controllers/PartnerController.php
@@ -59,8 +59,11 @@ class PartnerController extends Controller
         $editableTransaction = null;
         $year = request('year', date('Y'));
         $categories = $this->getCategoryList();
-        $startDate = request('start_date', date('Y-m').'-01');
+
+        $defaultStartDate = auth()->user()->account_start_date ?: date('Y-m').'-01';
+        $startDate = request('start_date', $defaultStartDate);
         $endDate = request('end_date', date('Y-m-d'));
+
         $transactions = $this->getPartnerTransactions($partner, [
             'category_id' => request('category_id'),
             'start_date'  => $startDate,

--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -20,6 +20,8 @@ class TransactionsController extends Controller
         $yearMonth = $this->getYearMonth();
         $year = request('year', date('Y'));
         $month = request('month', date('m'));
+        $defaultStartDate = auth()->user()->account_start_date;
+        $startDate = $defaultStartDate ?: $year.'-'.$month.'-01';
 
         $transactions = $this->getTansactions($yearMonth);
 
@@ -36,7 +38,8 @@ class TransactionsController extends Controller
         return view('transactions.index', compact(
             'transactions', 'editableTransaction',
             'yearMonth', 'month', 'year', 'categories',
-            'incomeTotal', 'spendingTotal', 'partners'
+            'incomeTotal', 'spendingTotal', 'partners',
+            'startDate'
         ));
     }
 

--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -94,7 +94,7 @@ class TransactionsController extends Controller
                     $transaction->category_id,
                     'start_date' => $transactionUpateForm->get('start_date'),
                     'end_date'   => $transactionUpateForm->get('end_date'),
-                    'partner_id' => $transactionUpateForm->get('queried_partner_id'),
+                    'partner_id' => $transactionUpateForm->get('partner_id'),
                     'query'      => $transactionUpateForm->get('query'),
                 ]);
             }

--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -85,7 +85,7 @@ class TransactionsController extends Controller
                     $transaction->partner_id,
                     'start_date'  => $transactionUpateForm->get('start_date'),
                     'end_date'    => $transactionUpateForm->get('end_date'),
-                    'category_id' => $transactionUpateForm->get('queried_category_id'),
+                    'category_id' => $transactionUpateForm->get('category_id'),
                     'query'       => $transactionUpateForm->get('query'),
                 ]);
             }

--- a/app/User.php
+++ b/app/User.php
@@ -15,7 +15,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'api_token',
+        'name', 'email', 'password', 'api_token', 'account_start_date',
     ];
 
     /**

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->char('api_token', 24);
             $table->boolean('is_active')->default(1);
+            $table->date('account_start_date')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });

--- a/resources/lang/en/user.php
+++ b/resources/lang/en/user.php
@@ -26,11 +26,12 @@ return [
     'undeleted' => 'User not deleted.',
 
     // Attributes
-    'name'          => 'User Name',
-    'email'         => 'Email Address',
-    'phone'         => 'Phone',
-    'is_active'     => 'User Status',
-    'registered_at' => 'Registered at',
+    'name'               => 'User Name',
+    'email'              => 'Email Address',
+    'phone'              => 'Phone',
+    'is_active'          => 'User Status',
+    'registered_at'      => 'Registered at',
+    'account_start_date' => 'Account Start Date',
 
     // Relations
     'groups' => 'Member List',

--- a/resources/lang/id/user.php
+++ b/resources/lang/id/user.php
@@ -26,11 +26,12 @@ return [
     'undeleted' => 'Data User gagal dihapus.',
 
     // Attributes
-    'name'          => 'Nama User',
-    'email'         => 'Alamat Email',
-    'phone'         => 'Telp/Hp.',
-    'is_active'     => 'Status User',
-    'registered_at' => 'Terdaftar sejak',
+    'name'               => 'Nama User',
+    'email'              => 'Alamat Email',
+    'phone'              => 'Telp/Hp.',
+    'is_active'          => 'Status User',
+    'registered_at'      => 'Terdaftar sejak',
+    'account_start_date' => 'Akun Mulai Digunakan',
 
     // Relations
     'groups' => 'List Member',

--- a/resources/views/auth/profile/edit.blade.php
+++ b/resources/views/auth/profile/edit.blade.php
@@ -11,6 +11,7 @@
                 <div class="panel-body">
                     {!! FormField::text('name', ['required' => true]) !!}
                     {!! FormField::email('email', ['required' => true]) !!}
+                    {!! FormField::text('account_start_date') !!}
                 </div>
                 <div class="panel-footer">
                     {{ Form::submit(__('user.profile_update'), ['class' => 'btn btn-success']) }}
@@ -21,3 +22,21 @@
     </div>
 </div>
 @endsection
+
+@section('styles')
+{{ Html::style(url('css/plugins/jquery.datetimepicker.css')) }}
+@endsection
+
+@push('scripts')
+{{ Html::script(url('js/plugins/jquery.datetimepicker.js')) }}
+<script>
+(function () {
+    $('#account_start_date').datetimepicker({
+        timepicker:false,
+        format:'Y-m-d',
+        closeOnDateSelect: true,
+        scrollInput: false
+    });
+})();
+</script>
+@endpush

--- a/resources/views/auth/profile/show.blade.php
+++ b/resources/views/auth/profile/show.blade.php
@@ -13,6 +13,7 @@
                 <tbody>
                     <tr><td>{{ __('user.name') }}</td><td>{{ $user->name }}</td></tr>
                     <tr><td>{{ __('user.email') }}</td><td>{{ $user->email }}</td></tr>
+                    <tr><td>{{ __('user.account_start_date') }}</td><td>{{ $user->account_start_date }}</td></tr>
                 </tbody>
             </table>
             <div class="panel-footer">

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -50,7 +50,7 @@
                                 @php
                                     $partnerRoute = route('partners.show', [
                                         $transaction->partner_id,
-                                        'start_date' => $year.'-'.$month.'-01',
+                                        'start_date' => $startDate,
                                         'end_date' => $year.'-'.$month.'-'.date('t'),
                                     ]);
                                 @endphp
@@ -58,7 +58,7 @@
                                 @php
                                     $categoryRoute = route('categories.show', [
                                         $transaction->category_id,
-                                        'start_date' => $year.'-'.$month.'-01',
+                                        'start_date' => $startDate,
                                         'end_date' => $year.'-'.$month.'-'.date('t'),
                                     ]);
                                 @endphp

--- a/resources/views/transactions/partials/single_transaction_mobile.blade.php
+++ b/resources/views/transactions/partials/single_transaction_mobile.blade.php
@@ -20,7 +20,7 @@
     @php
         $partnerRoute = route('partners.show', [
             $transaction->partner_id,
-            'start_date' => $year.'-'.$month.'-01',
+            'start_date' => $startDate,
             'end_date' => $year.'-'.$month.'-'.date('t'),
         ]);
     @endphp
@@ -28,7 +28,7 @@
     @php
         $categoryRoute = route('categories.show', [
             $transaction->category_id,
-            'start_date' => $year.'-'.$month.'-01',
+            'start_date' => $startDate,
             'end_date' => $year.'-'.$month.'-'.date('t'),
         ]);
     @endphp

--- a/tests/Feature/Auth/UserProfileTest.php
+++ b/tests/Feature/Auth/UserProfileTest.php
@@ -27,8 +27,9 @@ class UserProfileTest extends TestCase
         $this->click(__('user.profile_edit'));
         $this->seeRouteIs('profile.edit');
         $this->submitForm(__('user.profile_update'), [
-            'name'  => 'User Baru',
-            'email' => 'user3@mail.com',
+            'name'               => 'User Baru',
+            'email'              => 'user3@mail.com',
+            'account_start_date' => '2016-06-01',
         ]);
 
         $this->seeRouteIs('profile.show');
@@ -36,9 +37,10 @@ class UserProfileTest extends TestCase
         $this->seeText('User Baru');
 
         $this->seeInDatabase('users', [
-            'id'    => $user->id,
-            'name'  => 'User Baru',
-            'email' => 'user3@mail.com',
+            'id'                 => $user->id,
+            'name'               => 'User Baru',
+            'email'              => 'user3@mail.com',
+            'account_start_date' => '2016-06-01',
         ]);
     }
 }

--- a/tests/Feature/Transactions/TransactionEditTest.php
+++ b/tests/Feature/Transactions/TransactionEditTest.php
@@ -167,8 +167,9 @@ class TransactionEditTest extends TestCase
 
         $this->seeRouteIs('partners.show', [
             $partner->id,
-            'end_date'   => $year.'-'.$month.'-28',
-            'start_date' => $date,
+            'category_id' => $category->id,
+            'end_date'    => $year.'-'.$month.'-28',
+            'start_date'  => $date,
         ]);
         $this->see(__('transaction.updated'));
 

--- a/tests/Feature/Transactions/TransactionEditTest.php
+++ b/tests/Feature/Transactions/TransactionEditTest.php
@@ -269,6 +269,7 @@ class TransactionEditTest extends TestCase
         $this->seeRouteIs('categories.show', [
             $category->id,
             'end_date'   => $year.'-'.$month.'-28',
+            'partner_id' => $partner->id,
             'start_date' => $date,
         ]);
         $this->see(__('transaction.updated'));


### PR DESCRIPTION
In this PR, we are add new column on `users` table : `account_start_date`, which will be used as default start date of partner and category transaction listing.