### PR TITLE
Prevent oauth/token hang using access route internal

### DIFF
--- a/app/Http/Controllers/Api/Auth/AuthController.php
+++ b/app/Http/Controllers/Api/Auth/AuthController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api\Auth;
 
+use Route;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
-use Route;
 
 class AuthController extends Controller
 {


### PR DESCRIPTION
Mengapa?

Jika user menggunakan perintah `php artisan serve` dan tidak menggunakan Valet atau homestead untuk membuat dummy domain (embel" `.test`) maka yang akan terjadi adalah saat menggunakan Guzzle maupun Curl adalah request bolak balik dan ujung"nya hang.

Solusi yang bisa ditawarkan adalah mengirim data tersebut lewat route internal seperti yang disebutkan di forum SO: https://stackoverflow.com/questions/51000573/laravel-5-6-pass-oauth-token-hanging.

Saya barusan sudah mencoba untuk dummy domain maupun dengan localhost.