### PR TITLE
Yearly Report in Weeks

### DIFF
--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+
 /**
  * Function helper to add flash notification.
  *

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -1,4 +1,6 @@
 <?php
+
+use Carbon\Carbon;
 /**
  * Function helper to add flash notification.
  *
@@ -55,4 +57,11 @@ function balance($perDate = null, $startDate = null, $categoryId = null, $partne
     return $transactions->sum(function ($transaction) {
         return $transaction->in_out ? $transaction->amount : -$transaction->amount;
     });
+}
+
+function get_week_numbers(string $year): array
+{
+    $lastWeekOfTheYear = Carbon::parse($year.'-01-01')->weeksInYear();
+
+    return range(0, $lastWeekOfTheYear);
 }

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -21,8 +21,14 @@ class ReportsController extends Controller
         $categories = $this->getCategoryList();
         $year = $this->getYearQuery($request->get('year'));
         $reportFormat = $request->get('format', 'in_months');
-        $data = $this->getYearlyTransactionSummary($year, auth()->id(), $partnerId, $categoryId);
-        $chartData = $this->getYearlyReportChartData($data);
+
+        if ($reportFormat == 'in_weeks') {
+            $data = $this->getYearlyTransactionInWeeksSummary($year, auth()->id(), $partnerId, $categoryId);
+            $chartData = $this->getYearlyReportInWeeksChartData($year, $data);
+        } else {
+            $data = $this->getYearlyTransactionSummary($year, auth()->id(), $partnerId, $categoryId);
+            $chartData = $this->getYearlyReportChartData($data);
+        }
 
         return view('reports.index', compact(
             'year', 'data', 'partners', 'partnerId', 'categories', 'categoryId', 'chartData', 'reportFormat'
@@ -98,6 +104,62 @@ class ReportsController extends Controller
         $chartData = $reportData->map(function ($item) {
             return [
                 'month' => month_id($item->month),
+                'income' => $item->income,
+                'spending' => $item->spending,
+                'difference' => $item->difference,
+            ];
+        });
+
+        return $defaultMonthValues->replace($chartData)->values();
+    }
+
+    private function getYearlyTransactionInWeeksSummary($year, $userId, $partnerId = null, $categoryId = null)
+    {
+        $rawQuery = 'WEEK(date, 1) as week';
+        $rawQuery .= ', count(`id`) as count';
+        $rawQuery .= ', sum(if(in_out = 1, amount, 0)) AS income';
+        $rawQuery .= ', sum(if(in_out = 0, amount, 0)) AS spending';
+
+        $reportQuery = DB::table('transactions')->select(DB::raw($rawQuery))
+            ->where(DB::raw('YEAR(date)'), $year)
+            ->where('creator_id', $userId);
+
+        if ($partnerId) {
+            $reportQuery->where('partner_id', $partnerId);
+        }
+
+        if ($categoryId) {
+            $reportQuery->where('category_id', $categoryId);
+        }
+
+        $reportsData = $reportQuery->orderBy('date', 'ASC')
+            ->groupBy(DB::raw('WEEK(date, 1)'))
+            ->get();
+
+        $reports = [];
+        foreach ($reportsData as $report) {
+            $key = $report->week;
+            $reports[$key] = $report;
+            $reports[$key]->difference = $report->income - $report->spending;
+        }
+
+        return collect($reports);
+    }
+
+    public function getYearlyReportInWeeksChartData($year, $reportData)
+    {
+        $defaultMonthValues = collect(get_week_numbers($year))->map(function ($item, $key) {
+            return [
+                'week' => $key,
+                'income' => 0,
+                'spending' => 0,
+                'difference' => 0,
+            ];
+        });
+
+        $chartData = $reportData->map(function ($item) {
+            return [
+                'week' => $item->week,
                 'income' => $item->income,
                 'spending' => $item->spending,
                 'difference' => $item->difference,

--- a/app/Http/Controllers/TransactionSearchController.php
+++ b/app/Http/Controllers/TransactionSearchController.php
@@ -19,8 +19,10 @@ class TransactionSearchController extends Controller
         $partnerId = $request->get('partner_id');
         if ($searchQuery) {
             $transactionQuery = Transaction::orderBy('date', 'desc');
-            $transactionQuery->where('description', 'like', '%'.$searchQuery.'%');
             $transactionQuery->whereBetween('date', [$startDate, $endDate]);
+            if ($searchQuery != '---') {
+                $transactionQuery->where('description', 'like', '%'.$searchQuery.'%');
+            }
             if ($categoryId) {
                 $transactionQuery->where('category_id', $categoryId);
             }

--- a/resources/lang/en/report.php
+++ b/resources/lang/en/report.php
@@ -10,4 +10,7 @@ return [
     'graph' => 'Summary Graph',
     'detail' => 'Report Detail',
     'view_monthly' => 'View Monthly',
+    'monthly' => 'Report Month :year_month',
+    'view_weekly' => 'View Weekly',
+    'weekly' => 'Report Week :year_week',
 ];

--- a/resources/lang/en/report.php
+++ b/resources/lang/en/report.php
@@ -1,11 +1,13 @@
 <?php
 
 return [
-    'report'            => 'Report',
+    'report' => 'Report',
+    'in_months' => 'In Months',
+    'in_weeks' => 'In Weeks',
     'view_yearly_label' => 'View Yearly',
-    'view_report'       => 'View Report',
-    'this_year'         => 'This Year',
-    'graph'             => 'Summary Graph',
-    'detail'            => 'Report Detail',
-    'view_monthly'      => 'View Monthly',
+    'view_report' => 'View Report',
+    'this_year' => 'This Year',
+    'graph' => 'Summary Graph',
+    'detail' => 'Report Detail',
+    'view_monthly' => 'View Monthly',
 ];

--- a/resources/lang/en/time.php
+++ b/resources/lang/en/time.php
@@ -1,7 +1,8 @@
 <?php
 
 return [
-    'date'  => 'Date',
+    'date' => 'Date',
+    'week' => 'Week',
     'month' => 'Month',
 
     'months' => [
@@ -20,5 +21,5 @@ return [
     ],
 
     'start_date' => 'Start Date',
-    'end_date'   => 'End Date',
+    'end_date' => 'End Date',
 ];

--- a/resources/lang/id/report.php
+++ b/resources/lang/id/report.php
@@ -1,11 +1,13 @@
 <?php
 
 return [
-    'report'            => 'Laporan',
+    'report' => 'Laporan',
+    'in_months' => 'Bulanan',
+    'in_weeks' => 'Mingguan',
     'view_yearly_label' => 'Lihat Tahun',
-    'view_report'       => 'Lihat Laporan',
-    'this_year'         => 'Tahun Ini',
-    'graph'             => 'Grafik Summary',
-    'detail'            => 'Detail Laporan',
-    'view_monthly'      => 'Lihat Bulanan',
+    'view_report' => 'Lihat Laporan',
+    'this_year' => 'Tahun Ini',
+    'graph' => 'Grafik Summary',
+    'detail' => 'Detail Laporan',
+    'view_monthly' => 'Lihat Bulanan',
 ];

--- a/resources/lang/id/report.php
+++ b/resources/lang/id/report.php
@@ -10,4 +10,7 @@ return [
     'graph' => 'Grafik Summary',
     'detail' => 'Detail Laporan',
     'view_monthly' => 'Lihat Bulanan',
+    'monthly' => 'Laporan Bulan :year_month',
+    'view_weekly' => 'Lihat Mingguan',
+    'weekly' => 'Laporan Minggu :year_week',
 ];

--- a/resources/lang/id/time.php
+++ b/resources/lang/id/time.php
@@ -1,7 +1,8 @@
 <?php
 
 return [
-    'date'  => 'Tanggal',
+    'date' => 'Tanggal',
+    'week' => 'Minggu',
     'month' => 'Bulan',
 
     'months' => [
@@ -20,5 +21,5 @@ return [
     ],
 
     'start_date' => 'Tanggal Mulai',
-    'end_date'   => 'Tanggal Akhir',
+    'end_date' => 'Tanggal Akhir',
 ];

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -16,6 +16,7 @@
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-2']) }}
             {{ link_to_route('reports.index', __('report.this_year'), [], ['class' => 'btn btn-secondary mr-2']) }}
         </div>
+        {{ Form::hidden('format', request('format')) }}
         {{ Form::close() }}
     </div>
 </div>
@@ -29,7 +30,13 @@
 </div>
 
 <div class="card table-responsive">
-    <div class="card-header"><h3 class="card-title">{{ __('report.detail') }}</h3></div>
+    <div class="card-header">
+        <h3 class="card-title">{{ __('report.detail') }}</h3>
+        <div class="card-options btn-group" role="group">
+            {{ link_to_route('reports.index', __('report.in_months'), array_merge(request()->all(), ['format' => 'in_months']), ['class' => 'btn btn-sm '.(in_array(request('format'), ['in_months', null]) ? 'btn-info' : 'btn-secondary')]) }}
+            {{ link_to_route('reports.index', __('report.in_weeks'), array_merge(request()->all(), ['format' => 'in_weeks']), ['class' => 'btn btn-sm '.(in_array(request('format'), ['in_weeks']) ? 'btn-info' : 'btn-secondary')]) }}
+        </div>
+    </div>
     <div class="card-body table-responsive">
         @includeWhen($reportFormat == 'in_months', 'reports.partials.yearly_in_months', compact('data'))
         @includeWhen($reportFormat == 'in_weeks', 'reports.partials.yearly_in_weeks', compact('data'))

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -31,56 +31,7 @@
 <div class="card table-responsive">
     <div class="card-header"><h3 class="card-title">{{ __('report.detail') }}</h3></div>
     <div class="card-body table-responsive">
-        <table class="table table-sm table-responsive-sm table-hover">
-            <thead>
-                <th class="text-center">{{ __('time.month') }}</th>
-                <th class="text-center">{{ __('transaction.transaction') }}</th>
-                <th class="text-right">{{ __('transaction.income') }}</th>
-                <th class="text-right">{{ __('transaction.spending') }}</th>
-                <th class="text-right">{{ __('transaction.difference') }}</th>
-                <th class="text-center">{{ __('app.action') }}</th>
-            </thead>
-            <tbody>
-                @php $chartData = []; @endphp
-                @foreach(get_months() as $monthNumber => $monthName)
-                @php
-                    $any = isset($data[$monthNumber]);
-                @endphp
-                <tr>
-                    <td class="text-center">{{ month_id($monthNumber) }}</td>
-                    <td class="text-center">{{ $any ? $data[$monthNumber]->count : 0 }}</td>
-                    <td class="text-right text-nowrap">{{ format_number($income = ($any ? $data[$monthNumber]->income : 0)) }}</td>
-                    <td class="text-right text-nowrap">{{ format_number($spending = ($any ? $data[$monthNumber]->spending : 0)) }}</td>
-                    <td class="text-right text-nowrap">{{ format_number($difference = ($any ? $data[$monthNumber]->difference : 0)) }}</td>
-                    <td class="text-center text-nowrap">
-                        {{ link_to_route(
-                            'transactions.index',
-                            __('report.view_monthly'),
-                            ['month' => $monthNumber, 'year' => $year, 'partner_id' => $partnerId],
-                            [
-                                'class' => 'btn btn-secondary btn-sm',
-                                'title' => __('report.monthly', ['year_month' => month_id($monthNumber)]),
-                                'title' => __('report.monthly', ['year_month' => month_id($monthNumber).' '.$year]),
-                            ]
-                        ) }}
-                    </td>
-                </tr>
-                @php
-                    $chartData[] = ['month' => month_id($monthNumber), 'income' => $income, 'spending' => $spending, 'difference' => $difference];
-                @endphp
-                @endforeach
-            </tbody>
-            <tfoot>
-                <tr>
-                    <th class="text-center">{{ trans('app.total') }}</th>
-                    <th class="text-center">{{ $data->sum('count') }}</th>
-                    <th class="text-right">{{ format_number($data->sum('income')) }}</th>
-                    <th class="text-right">{{ format_number($data->sum('spending')) }}</th>
-                    <th class="text-right">{{ format_number($data->sum('difference')) }}</th>
-                    <td>&nbsp;</td>
-                </tr>
-            </tfoot>
-        </table>
+        @includeWhen($reportFormat == 'in_months', 'reports.partials.yearly_in_months', compact('data'))
     </div>
 </div>
 @endsection

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -32,6 +32,7 @@
     <div class="card-header"><h3 class="card-title">{{ __('report.detail') }}</h3></div>
     <div class="card-body table-responsive">
         @includeWhen($reportFormat == 'in_months', 'reports.partials.yearly_in_months', compact('data'))
+        @includeWhen($reportFormat == 'in_weeks', 'reports.partials.yearly_in_weeks', compact('data'))
     </div>
 </div>
 @endsection
@@ -48,7 +49,7 @@
     new Morris.Line({
         element: 'yearly-chart',
         data: {!! collect($chartData)->toJson() !!},
-        xkey: 'month',
+        xkey: "{{ in_array(request('format'), ['in_weeks']) ? 'week' : 'month' }}",
         ykeys: ['income', 'spending', 'difference'],
         labels: ["{{ __('transaction.income') }} {{ auth()->user()->currency_code }}", "{{ __('transaction.spending') }} {{ auth()->user()->currency_code }}", "{{ __('transaction.difference') }} {{ auth()->user()->currency_code }}"],
         parseTime:false,

--- a/resources/views/reports/partials/yearly_in_months.blade.php
+++ b/resources/views/reports/partials/yearly_in_months.blade.php
@@ -1,0 +1,46 @@
+<table class="table table-sm table-responsive-sm table-hover">
+    <thead>
+        <th class="text-center">{{ __('time.month') }}</th>
+        <th class="text-center">{{ __('transaction.transaction') }}</th>
+        <th class="text-right">{{ __('transaction.income') }}</th>
+        <th class="text-right">{{ __('transaction.spending') }}</th>
+        <th class="text-right">{{ __('transaction.difference') }}</th>
+        <th class="text-center">{{ __('app.action') }}</th>
+    </thead>
+    <tbody>
+        @foreach(get_months() as $monthNumber => $monthName)
+        @php
+            $any = isset($data[$monthNumber]);
+        @endphp
+        <tr>
+            <td class="text-center">{{ month_id($monthNumber) }}</td>
+            <td class="text-center">{{ $any ? $data[$monthNumber]->count : 0 }}</td>
+            <td class="text-right text-nowrap">{{ format_number($income = ($any ? $data[$monthNumber]->income : 0)) }}</td>
+            <td class="text-right text-nowrap">{{ format_number($spending = ($any ? $data[$monthNumber]->spending : 0)) }}</td>
+            <td class="text-right text-nowrap">{{ format_number($difference = ($any ? $data[$monthNumber]->difference : 0)) }}</td>
+            <td class="text-center text-nowrap">
+                {{ link_to_route(
+                    'transactions.index',
+                    __('report.view_monthly'),
+                    ['month' => $monthNumber, 'year' => $year, 'partner_id' => $partnerId],
+                    [
+                        'class' => 'btn btn-secondary btn-sm',
+                        'title' => __('report.monthly', ['year_month' => month_id($monthNumber)]),
+                        'title' => __('report.monthly', ['year_month' => month_id($monthNumber).' '.$year]),
+                    ]
+                ) }}
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+    <tfoot>
+        <tr>
+            <th class="text-center">{{ trans('app.total') }}</th>
+            <th class="text-center">{{ $data->sum('count') }}</th>
+            <th class="text-right">{{ format_number($data->sum('income')) }}</th>
+            <th class="text-right">{{ format_number($data->sum('spending')) }}</th>
+            <th class="text-right">{{ format_number($data->sum('difference')) }}</th>
+            <td>&nbsp;</td>
+        </tr>
+    </tfoot>
+</table>

--- a/resources/views/reports/partials/yearly_in_months.blade.php
+++ b/resources/views/reports/partials/yearly_in_months.blade.php
@@ -22,10 +22,9 @@
                 {{ link_to_route(
                     'transactions.index',
                     __('report.view_monthly'),
-                    ['month' => $monthNumber, 'year' => $year, 'partner_id' => $partnerId],
+                    ['month' => $monthNumber, 'year' => $year, 'partner_id' => $partnerId, 'category_id' => $categoryId],
                     [
                         'class' => 'btn btn-secondary btn-sm',
-                        'title' => __('report.monthly', ['year_month' => month_id($monthNumber)]),
                         'title' => __('report.monthly', ['year_month' => month_id($monthNumber).' '.$year]),
                     ]
                 ) }}
@@ -35,7 +34,7 @@
     </tbody>
     <tfoot>
         <tr>
-            <th class="text-center">{{ trans('app.total') }}</th>
+            <th class="text-center">{{ __('app.total') }}</th>
             <th class="text-center">{{ $data->sum('count') }}</th>
             <th class="text-right">{{ format_number($data->sum('income')) }}</th>
             <th class="text-right">{{ format_number($data->sum('spending')) }}</th>

--- a/resources/views/reports/partials/yearly_in_weeks.blade.php
+++ b/resources/views/reports/partials/yearly_in_weeks.blade.php
@@ -1,0 +1,55 @@
+<table class="table table-sm table-responsive-sm table-hover">
+    <thead>
+        <th class="text-center">{{ __('time.week') }}</th>
+        <th class="text-center">{{ __('time.date') }}</th>
+        <th class="text-center">{{ __('transaction.transaction') }}</th>
+        <th class="text-right">{{ __('transaction.income') }}</th>
+        <th class="text-right">{{ __('transaction.spending') }}</th>
+        <th class="text-right">{{ __('transaction.difference') }}</th>
+        <th class="text-center">{{ __('app.action') }}</th>
+    </thead>
+    <tbody>
+        @foreach(get_week_numbers($year) as $weekNumber => $weekName)
+        @php
+            $any = isset($data[$weekNumber]);
+        @endphp
+        <tr>
+            <td class="text-center">{{ $weekNumber }}</td>
+            <td class="text-center text-nowrap">
+                @php
+                    $date = now();
+                    $date->setISODate($year, $weekNumber);
+                @endphp
+                {{ $startDate = $loop->first ? $year.'-01-01' : $date->startOfWeek()->format('Y-m-d') }} -
+                {{ $endDate = $loop->last ? $year.'-12-31' : $date->endOfWeek()->format('Y-m-d') }}
+            </td>
+            <td class="text-center">{{ $any ? $data[$weekNumber]->count : 0 }}</td>
+            <td class="text-right text-nowrap">{{ format_number($income = ($any ? $data[$weekNumber]->income : 0)) }}</td>
+            <td class="text-right text-nowrap">{{ format_number($spending = ($any ? $data[$weekNumber]->spending : 0)) }}</td>
+            <td class="text-right text-nowrap">{{ format_number($difference = ($any ? $data[$weekNumber]->difference : 0)) }}</td>
+            <td class="text-center text-nowrap">
+                {{-- {{ link_to_route(
+                    'transactions.index',
+                    __('report.view_weekly'),
+                    ['week' => $weekNumber, 'year' => $year, 'partner_id' => $partnerId],
+                    [
+                        'class' => 'btn btn-secondary btn-sm',
+                        'title' => __('report.weekly', ['year_week' => week_id($weekNumber)]),
+                        'title' => __('report.weekly', ['year_week' => week_id($weekNumber).' '.$year]),
+                    ]
+                ) }} --}}
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+    <tfoot>
+        <tr>
+            <th class="text-center" colspan="2">{{ trans('app.total') }}</th>
+            <th class="text-center">{{ $data->sum('count') }}</th>
+            <th class="text-right">{{ format_number($data->sum('income')) }}</th>
+            <th class="text-right">{{ format_number($data->sum('spending')) }}</th>
+            <th class="text-right">{{ format_number($data->sum('difference')) }}</th>
+            <td>&nbsp;</td>
+        </tr>
+    </tfoot>
+</table>

--- a/resources/views/reports/partials/yearly_in_weeks.blade.php
+++ b/resources/views/reports/partials/yearly_in_weeks.blade.php
@@ -28,23 +28,28 @@
             <td class="text-right text-nowrap">{{ format_number($spending = ($any ? $data[$weekNumber]->spending : 0)) }}</td>
             <td class="text-right text-nowrap">{{ format_number($difference = ($any ? $data[$weekNumber]->difference : 0)) }}</td>
             <td class="text-center text-nowrap">
-                {{-- {{ link_to_route(
-                    'transactions.index',
+                {{ link_to_route(
+                    'transaction_search.index',
                     __('report.view_weekly'),
-                    ['week' => $weekNumber, 'year' => $year, 'partner_id' => $partnerId],
+                    [
+                        'search_query' => '---',
+                        'start_date' => $startDate,
+                        'end_date' => $endDate,
+                        'partner_id' => $partnerId,
+                        'category_id' => $categoryId
+                    ],
                     [
                         'class' => 'btn btn-secondary btn-sm',
-                        'title' => __('report.weekly', ['year_week' => week_id($weekNumber)]),
-                        'title' => __('report.weekly', ['year_week' => week_id($weekNumber).' '.$year]),
+                        'title' => __('report.weekly', ['year_week' => $year.'-'.$weekNumber]),
                     ]
-                ) }} --}}
+                ) }}
             </td>
         </tr>
         @endforeach
     </tbody>
     <tfoot>
         <tr>
-            <th class="text-center" colspan="2">{{ trans('app.total') }}</th>
+            <th class="text-center" colspan="2">{{ __('app.total') }}</th>
             <th class="text-center">{{ $data->sum('count') }}</th>
             <th class="text-right">{{ format_number($data->sum('income')) }}</th>
             <th class="text-right">{{ format_number($data->sum('spending')) }}</th>


### PR DESCRIPTION
## Description

In this PR we are adding a new reporting feature to view the yearly report in weeks format. So we will have 2 types of report in the yearly report:
1. In month format
2. In weeks format

## Checklist

- [x] Move monthly report table into view partial
- [x] Add a new view partial for in_weeks yearly report
- [x] Add queries to calculate yearly report in weeks format
- [x] Add report format switcher (In months or In weeks)
- [x] Add report detail button for each week report (go to the search transactions page within date range)

## How to test on localhost

Checkout to the branch
```
git fetch origin
git checkout yearly_in_weeks
```
Run web server for the dompet webapp: In terminal
```
$ php artisan serve
```
1. Open the web using the browser.
2. Head over to the **Report** page.
3. Check on the **Report Detail** section, there is a report format switch between **In Months** and **In Weeks**.
4. Switch the report format button to see the difference.

The expected result:

1. The transactions count, income, spending, and difference is correct for each week rows (check the date range).

## Screenshots

The new In Weeks report format

![screen_2021-12-05_002](https://user-images.githubusercontent.com/8721551/144752248-a5d1f427-235b-4a26-a707-c4a20c69c9b1.jpg)


